### PR TITLE
Improve stream handling

### DIFF
--- a/src/openai.rs
+++ b/src/openai.rs
@@ -184,16 +184,13 @@ pub async fn stream_chat_completion(
     key: &Key,
     model: &str,
     messages: &[Message],
-) -> Result<
-    Pin<Box<dyn Stream<Item = Result<ChatCompletionChunk, Box<dyn Error + Send + Sync>>> + Send>>,
-    Box<dyn Error + Send + Sync>,
-> {
+) -> Result<Pin<Box<dyn Stream<Item = ChatCompletionChunk> + Send>>, Box<dyn Error + Send + Sync>> {
     let resp = request_chat_completion(key, model, true, messages).await?;
     let mut buffer = String::new();
     let stream = resp
         .bytes_stream()
         .map_err(|e| Box::new(e) as Box<dyn Error + Send + Sync>)
-        .flat_map(|chunk_result| {
+        .flat_map(move |chunk_result| {
             let chunk = chunk_result.unwrap();
             let text = String::from_utf8_lossy(&chunk);
             // Split on "data: " prefix and filter empty lines

--- a/src/openai.rs
+++ b/src/openai.rs
@@ -164,22 +164,13 @@ fn process_line(line: &str, buffer: &mut String) -> Option<ChatCompletionChunk> 
         if json_str.is_empty() {
             return None;
         }
-        // To debug intermittent EOF while parsing string.
-        println!("{}", json_str);
-        match parse_str(json_str) {
-            Some(json) => Some(json),
-            None => {
-                buffer.push_str(json_str);
-                None
-            }
-        }
+        
+        todo!()
     } else {
         None
     }
 }
 
-/// Convert a streaming response into an iterator of JSON messages.
-/// Each message represents a complete chunk from the stream.
 pub async fn stream_chat_completion(
     key: &Key,
     model: &str,

--- a/tests/openai.rs
+++ b/tests/openai.rs
@@ -124,7 +124,6 @@ async fn chat_completion_stream_helper(
         .unwrap();
     let mut content = String::new();
     while let Some(resp) = stream.next().await {
-        let resp = resp.unwrap();
         assert_eq!(resp.choices.len(), 1);
         let chunk = resp.choices[0].delta.content.clone().unwrap_or_default();
         content += &chunk;

--- a/tests/openai.rs
+++ b/tests/openai.rs
@@ -73,6 +73,15 @@ async fn test_chat_completion_no_stream_hyperbolic() {
 }
 
 #[tokio::test]
+async fn test_chat_completion_no_stream_hyperbolic_error() {
+    let out = test_chat_completion_no_stream(Provider::Hyperbolic, "foo").await;
+    assert!(out.is_err());
+    let err = out.unwrap_err();
+    println!("{}", err);
+    assert!(err.to_string().contains("allowed now, your model foo"));
+}
+
+#[tokio::test]
 async fn test_chat_completion_no_stream_google() {
     test_chat_completion_no_stream(Provider::Google, "gemini-1.5-flash")
         .await

--- a/tests/openai_extra.rs
+++ b/tests/openai_extra.rs
@@ -29,11 +29,7 @@ async fn test_chat_completion_stream_duration() {
     let mut timestamps = Vec::new();
     while let Some(resp) = stream.next().await {
         let timestamp = std::time::SystemTime::now();
-        let chunk = resp.unwrap().choices[0]
-            .delta
-            .content
-            .clone()
-            .unwrap_or_default();
+        let chunk = resp.choices[0].delta.content.clone().unwrap_or_default();
         content += &chunk;
         println!("{}", chunk);
         timestamps.push(timestamp);


### PR DESCRIPTION
Streaming responses do not have to be valid JSON on their own. This is also a valid response
```text
{"id":"chatcmpl-AyOFxPgQ0Z3vC9jU8Fwkmi1XtWQtP","object":"chat.completion.chunk","created":1738956285,"model":"gpt-4o-mini-2024-07-18","service_tier":"de  
```